### PR TITLE
Fix integrity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "redis"
     ],
     "require": {
-        "llegaz/redis-adapter": "^0.0.3",
+        "llegaz/redis-adapter": "^0.0.4",
         "psr/cache": "^3.0",
         "psr/simple-cache": "^3.0"
     },

--- a/src/RedisCache.php
+++ b/src/RedisCache.php
@@ -48,13 +48,6 @@ class RedisCache extends RedisAdapter implements CacheInterface
 
     protected const HASH_DB_PREFIX = 'DEFAULT_Cache_Pool';
 
-    /**
-     * Do we check for database integrity ? default = always
-     * 
-     * @var bool
-     */
-    protected bool $paranoid = true;
-
     public function __construct(
         string $host = RedisClientInterface::DEFAULTS['host'],
         int $port = RedisClientInterface::DEFAULTS['port'],
@@ -84,7 +77,7 @@ class RedisCache extends RedisAdapter implements CacheInterface
             if ($allDBs) {
                 $redisResponse = $this->getRedis()->flushAll();
             } else {
-                if ($this->paranoid && !$this->checkIntegrity()) {
+                if (!$this->checkIntegrity()) {
                     $this->throwLIEx();
                 }
                 $redisResponse = $this->getRedis()->flushdb();
@@ -119,7 +112,7 @@ class RedisCache extends RedisAdapter implements CacheInterface
         if (!$this->isConnected()) {
             $this->throwCLEx();
         }
-        if ($this->paranoid && !$this->checkIntegrity()) {
+        if (!$this->checkIntegrity()) {
             $this->throwLIEx();
         }
 
@@ -153,7 +146,7 @@ class RedisCache extends RedisAdapter implements CacheInterface
         if (!$this->isConnected()) {
             $this->throwCLEx();
         }
-        if ($this->paranoid && !$this->checkIntegrity()) {
+        if (!$this->checkIntegrity()) {
             $this->throwLIEx();
         }
 
@@ -184,7 +177,7 @@ class RedisCache extends RedisAdapter implements CacheInterface
         if (!$this->isConnected()) {
             $this->throwCLEx();
         }
-        if ($this->paranoid && !$this->checkIntegrity()) {
+        if (!$this->checkIntegrity()) {
             $this->throwLIEx();
         }
 
@@ -225,7 +218,7 @@ class RedisCache extends RedisAdapter implements CacheInterface
         if (!$this->isConnected()) {
             $this->throwCLEx();
         }
-        if ($this->paranoid && !$this->checkIntegrity()) {
+        if (!$this->checkIntegrity()) {
             $this->throwLIEx();
         }
 
@@ -274,7 +267,7 @@ class RedisCache extends RedisAdapter implements CacheInterface
         if (!$this->isConnected()) {
             $this->throwCLEx();
         }
-        if ($this->paranoid && !$this->checkIntegrity()) {
+        if (!$this->checkIntegrity()) {
             $this->throwLIEx();
         }
 
@@ -310,7 +303,7 @@ class RedisCache extends RedisAdapter implements CacheInterface
         if (!$this->isConnected()) {
             $this->throwCLEx();
         }
-        if ($this->paranoid && !$this->checkIntegrity()) {
+        if (!$this->checkIntegrity()) {
             $this->throwLIEx();
         }
 
@@ -357,7 +350,7 @@ class RedisCache extends RedisAdapter implements CacheInterface
         if (!$this->isConnected()) {
             $this->throwCLEx();
         }
-        if ($this->paranoid && !$this->checkIntegrity()) {
+        if (!$this->checkIntegrity()) {
             $this->throwLIEx();
         }
 
@@ -495,19 +488,5 @@ class RedisCache extends RedisAdapter implements CacheInterface
         $endTime = $reference->add($ttl);
 
         return $endTime->getTimestamp() - $reference->getTimestamp();
-    }
-
-    /**
-     * Do we check for database integrity ? default = always
-     * 
-     * you can disable all those integrity checks for performance purpose (at your own risks)
-     * 
-     * @param bool $paranoid
-     * @return self
-     */
-    public function setParanoid(bool $paranoid = true) :self {
-        $this->paranoid = $paranoid;
-
-        return $this;
     }
 }


### PR DESCRIPTION
**we need tegridy but not at the cost of performance** 

**Note:  performance won't be impacted in 1 to 1 setup**

_that is to say RedisCache or RedisAdapter or another concrete class using the single redis connection object dedicated to one redis instance_

- Try to keep 1 instantiated object to access 1 redis instance or cluster